### PR TITLE
Pass AT commands individually, fix parsing, fix serial options

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sabanto-modem-config (0.9.3) focal; urgency=low
+
+  * Pass AT commands individually, fix parsing, fix serial options
+
+ -- Adam Gaynor <adam.gaynor@sabantoag.com>  Wed, 07 Aug 2024 13:08:09 -0600
+
 sabanto-modem-config (0.9.2) focal; urgency=low
 
   * Add missing AT commands 

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,20 +1,34 @@
 #!/bin/bash
 
 set -e
+SERIAL_PORT=/dev/ttyUSB3
+OLD_SETTINGS=$(stty -g -F ${SERIAL_PORT})
+stty -F ${SERIAL_PORT} -igncr -icrnl -ixon -ixoff
+stty -F /dev/ttyUSB2 "$OLD_SETTINGS"
 
-atinout - /dev/ttyUSB3 - <<EOF
-ATE0
-AT
-AT#ENAEVMONI=0
-AT#ENAEVMONICFG=3,1,2
-AT#EVMONI="SMSIN",0,1,"TEST"
-AT#EVMONI="SMSIN",0,0,"AT#GPIO=3,0,1"
-AT#EVMONI="SMSIN",1
-AT#EVMONI="GPIO3",0,1,3
-AT#EVMONI="GPIO3",0,2,0
-AT#EVMONI="GPIO3",0,0,"AT#GPIO=3,1,1"
-AT#EVMONI="GPIO3",1
-AT#ENAEVMONI=1
-EOF
+echo 'ATE0' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#ENAEVMONI=0' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#ENAEVMONICFG=3,1,2' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#EVMONI="SMSIN",0,1,"TEST"' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#EVMONI="SMSIN",0,0,"AT#GPIO=3,0,1"' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#EVMONI="SMSIN",1' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#EVMONI="GPIO3",0,1,3' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#EVMONI="GPIO3",0,2,0' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#EVMONI="GPIO3",0,0,"AT#GPIO=3,1,1"' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#EVMONI="GPIO3",1' | atinout - ${SERIAL_PORT} -
+sleep 0.1
+echo 'AT#ENAEVMONI=1' | atinout - ${SERIAL_PORT} -
+sleep 0.1
 
 exit 0


### PR DESCRIPTION
The sleeps are probably not strictly necessary, but I added them to aid in debugging if an individual command fails. It is still unclear why not escaping the quotes included in the individual AT commands appears to work on both Brian and my PFM's, but this appeared to fix the unit in the field. I also put the serial port into a known state and restored whatever options were present before the update occurs.

Since sabanto-pfm-config pulls in this package, and always grabs the latest version, no updates other than pushing this to aptly should be needed. [REF](https://github.com/sabantoag/sabanto-pfm-config/blob/2c029a83326c9a8a943f97e4f174466336c39311/src/sabanto-pfm-config/debian/control#L17)